### PR TITLE
Do not require signed packages in doc generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,8 @@ jobs:
           # Install from local manifest
           ispm platforms --no-config-file --install-dir install --verbose \
               --platform-repo . --package-repo https://apis.intel.com \
-              --manifest qsp-x86-public-7 --non-interactive --create-project proj 
+              --manifest qsp-x86-public-7 --non-interactive \
+              --create-project proj --trust-insecure-packages
 
       - name: Generate Simics Documentation
         working-directory: proj


### PR DESCRIPTION
This works around that 1015 has an expired certificate.
